### PR TITLE
docs: Update README to TestMu AI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,111 @@
-# LambdaTest Homebrew-tap
+# Run LambdaTest Tunnel via Homebrew on TestMu AI (Formerly LambdaTest)
 
-Homebrew formulae that allows installation of Lambdatest tools through homebrew package manager.
+<p align="center">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://brew.sh/"><img src="https://img.shields.io/badge/Homebrew-macOS-brown.svg?style=for-the-badge&labelColor=000" alt="Homebrew macOS"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+</p>
 
-## How do I install these formula?
+## Getting Started
 
-`brew install lambdatest/tap-lambdatest-tunnel/lambdatest-tunnel`
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-Or `brew tap lambdatest/tap-lambdatest-tunnel` and then `brew install lambdatest-tunnel`.
+With TestMu AI (Formerly LambdaTest), you can install and manage the LambdaTest Tunnel CLI tool on macOS using Homebrew. This Homebrew tap provides formulae that allow easy installation of LambdaTest tools through the Homebrew package manager.
 
-## Formula
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
-| Formula | Description | 
-| ------- | ----------- | 
-| [lambdatest-tunnel ](https://github.com/lambdatest/homebrew-tap-lambdatest-tunnel) | CLI tool to start and stop LambdaTest tunnel (Support for 64bit macOS) |
+### Prerequisites
 
-## Documentation
+- macOS (64-bit)
+- [Homebrew](https://brew.sh/) package manager installed
+- A TestMu AI account. [Sign up for free](https://www.testmuai.com/register/).
+- TestMu AI `Username` and `Access Key` from the [TestMu AI Automation Dashboard](https://automation.testmuai.com/).
 
-`brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).
+### Setup
+
+Clone the repository:
+
+```bash
+git clone https://github.com/LambdaTest/homebrew-tap-lambdatest-tunnel
+```
+
+Or simply add the tap and install directly using Homebrew.
+
+### Run tests
+
+Install the LambdaTest Tunnel using Homebrew:
+
+```bash
+brew install lambdatest/tap-lambdatest-tunnel/lambdatest-tunnel
+```
+
+Alternatively, tap first then install:
+
+```bash
+brew tap lambdatest/tap-lambdatest-tunnel
+brew install lambdatest-tunnel
+```
+
+Once installed, start the tunnel with your TestMu AI credentials:
+
+```bash
+lambdatest-tunnel --user YOUR_USERNAME --key YOUR_ACCESS_KEY
+```
+
+| Formula | Description |
+| ------- | ----------- |
+| [lambdatest-tunnel](https://github.com/lambdatest/homebrew-tap-lambdatest-tunnel) | CLI tool to start and stop LambdaTest tunnel (Support for 64bit macOS) |
+
+For more help: `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).
+
+### Local testing with TestMu AI Tunnel
+
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
+
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+## Contributions
+
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and Angular CLI version.
+
+## TestMu AI (Formerly LambdaTest) Community
+
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
+
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
+
+## Learning Resources by TestMu AI (Formerly LambdaTest)
+
+Learn modern testing through tutorials, guides, videos, and weekly updates:
+
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
+
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
+
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
+
+ð Find the new home for [LambdaTest](https://www.testmuai.com).
+
+### How LambdaTest Evolved into TestMu AI
+
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
+
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
+
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
+
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+## Support
+
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.


### PR DESCRIPTION
Updates README to follow the standard TestMu AI (Formerly LambdaTest) template.