### PR TITLE
fix: Replace LambdaTest brand name with TestMu AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Run LambdaTest Tunnel via Homebrew on TestMu AI (Formerly LambdaTest)
+﻿# Run TestMu AI Tunnel via Homebrew on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -10,7 +10,7 @@
 
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-With TestMu AI (Formerly LambdaTest), you can install and manage the LambdaTest Tunnel CLI tool on macOS using Homebrew. This Homebrew tap provides formulae that allow easy installation of LambdaTest tools through the Homebrew package manager.
+With TestMu AI (Formerly LambdaTest), you can install and manage the TestMu AI (Formerly LambdaTest) Tunnel CLI tool on macOS using Homebrew. This Homebrew tap provides formulae that allow easy installation of TestMu AI (Formerly LambdaTest) tools through the Homebrew package manager.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
@@ -34,7 +34,7 @@ Or simply add the tap and install directly using Homebrew.
 
 ### Run tests
 
-Install the LambdaTest Tunnel using Homebrew:
+Install the TestMu AI (Formerly LambdaTest) Tunnel using Homebrew:
 
 ```bash
 brew install lambdatest/tap-lambdatest-tunnel/lambdatest-tunnel
@@ -55,7 +55,7 @@ lambdatest-tunnel --user YOUR_USERNAME --key YOUR_ACCESS_KEY
 
 | Formula | Description |
 | ------- | ----------- |
-| lambdatest-tunnel | CLI tool to start and stop LambdaTest tunnel (Support for 64bit macOS) |
+| lambdatest-tunnel | CLI tool to start and stop TestMu AI (Formerly LambdaTest) tunnel (Support for 64bit macOS) |
 
 For more help: `brew help`, `man brew` or check Homebrew's documentation.
 


### PR DESCRIPTION
Replaces all standalone LambdaTest brand mentions with TestMu AI (Formerly LambdaTest) in body text and TestMu AI in H1 title. Code blocks, URLs, badge HTML, and boilerplate are untouched.