### PR TITLE
fix: README - align with TestMu AI branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-﻿# Run TestMu AI Tunnel via Homebrew on TestMu AI (Formerly LambdaTest)
+# Homebrew Tap for TestMu AI (Formerly LambdaTest) Tunnel
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
-  <a href="https://brew.sh/"><img src="https://img.shields.io/badge/Homebrew-macOS-brown.svg?style=for-the-badge&labelColor=000" alt="Homebrew macOS"></a>
   <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
 
@@ -10,7 +9,7 @@
 
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-With TestMu AI (Formerly LambdaTest), you can install and manage the TestMu AI (Formerly LambdaTest) Tunnel CLI tool on macOS using Homebrew. This Homebrew tap provides formulae that allow easy installation of TestMu AI (Formerly LambdaTest) tools through the Homebrew package manager.
+This Homebrew tap for TestMu AI (Formerly LambdaTest) Tunnel provides formulae for easy installation of the Tunnel CLI tool on macOS through the Homebrew package manager.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.


### PR DESCRIPTION
Aligns README with TestMu AI branding: updated H1 title, badge block, brand names, and links per guidelines.